### PR TITLE
improve signed ticket ids

### DIFF
--- a/py/shared/utils.py
+++ b/py/shared/utils.py
@@ -136,7 +136,7 @@ def pseudo_random_str(length=10):
 
 def ticket_id_signed(ticket_id, settings: Settings):
     h = hmac.new(settings.auth_key.encode(), b'%d' % ticket_id, digestmod=hashlib.md5)
-    check = base64.urlsafe_b64encode(h.digest()).decode().lower()
+    check = re.sub(b'[^a-z0-9]', b'', base64.b64encode(h.digest()).lower()).decode()
     return f'{check:.7}-{ticket_id}'
 
 

--- a/py/tests/test_utils.py
+++ b/py/tests/test_utils.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import pytest
 from aiohttp.test_utils import make_mocked_request
 
-from shared.utils import RequestError, format_duration
+from shared.utils import RequestError, format_duration, ticket_id_signed
 from web.utils import clean_markdown, get_ip, pretty_lenient_json, split_name
 
 
@@ -89,3 +89,13 @@ def test_clean_markdown(input, output):
 ])
 def test_clean_markdown_unchanged(input):
     assert clean_markdown(input) == input
+
+
+@pytest.mark.parametrize('ticket_id,expected', [
+    (1, '9qs17sx-1'),
+    (123, '0tqg2o9-123'),
+    (321654, 'v1ivmda-123'),
+])
+def test_ticket_id_signed(ticket_id, expected):
+    settings = type('Settings', (), {'auth_key': 'this is the auth key'})
+    assert expected == ticket_id_signed(ticket_id, settings)

--- a/py/tests/test_utils.py
+++ b/py/tests/test_utils.py
@@ -92,10 +92,9 @@ def test_clean_markdown_unchanged(input):
 
 
 @pytest.mark.parametrize('ticket_id,expected', [
-    (1, '9qs17sx-1'),
-    (123, '0tqg2o9-123'),
-    (321654, 'v1ivmda-123'),
+    (1, 'hzjsbsm-1'),
+    (123, 'irorchu-123'),
+    (321654, 'admuo35-321654'),
 ])
-def test_ticket_id_signed(ticket_id, expected):
-    settings = type('Settings', (), {'auth_key': 'this is the auth key'})
+def test_ticket_id_signed(ticket_id, expected, settings):
     assert expected == ticket_id_signed(ticket_id, settings)


### PR DESCRIPTION
old ticket ids had confusing characters in the check part eg `_` and `-`. Now they don't