### PR TITLE
zero revenue when tickets are ordered by admins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ cache:
   yarn: true
   directories:
   - node_modules
+  - docker_images
 
 install:
+- ls docker_images/*.tar | xargs -i sh -c "docker load -i {}"
 - pip install -U pip setuptools
 - pip install -r py/tests/requirements.txt
 - pip install -r py/requirements.txt
@@ -40,3 +42,7 @@ script:
 #- bash <(curl -s https://codecov.io/bash)
 - make build
 - ls -lha
+
+before_cache:
+- docker images -a
+- docker save -o docker_images/images.tar $(docker images -a -q)

--- a/py/tests/test_booking.py
+++ b/py/tests/test_booking.py
@@ -585,6 +585,7 @@ async def test_buy_offline(cli, url, dummy_server, factory: Factory, login, db_c
 
     res: Reservation = await factory.create_reservation()
     app = cli.app['main_app']
+    assert 10 == await db_conn.fetchval('SELECT price FROM tickets')
 
     data = dict(
         booking_token=encrypt_json(app, res.dict()),
@@ -601,6 +602,8 @@ async def test_buy_offline(cli, url, dummy_server, factory: Factory, login, db_c
     ]
     assert 0 == await db_conn.fetchval("SELECT COUNT(*) FROM actions WHERE type='book-free-tickets'")
     assert 1 == await db_conn.fetchval("SELECT COUNT(*) FROM actions WHERE type='buy-tickets-offline'")
+    assert 1 == await db_conn.fetchval('SELECT COUNT(*) FROM tickets')
+    assert None is await db_conn.fetchval('SELECT price FROM tickets')
 
 
 async def test_buy_offline_other_admin(cli, url, dummy_server, factory: Factory, login, db_conn):

--- a/py/tests/test_donorfy.py
+++ b/py/tests/test_donorfy.py
@@ -238,7 +238,7 @@ async def test_book_multiple(donorfy: DonorfyActor, factory: Factory, dummy_serv
     }
 
 
-async def test_book_free_no_fee(donorfy: DonorfyActor, factory: Factory, dummy_server, cli, url, login):
+async def test_book_offline(donorfy: DonorfyActor, factory: Factory, dummy_server, cli, url, login):
     await factory.create_company()
     await factory.create_cat()
     await factory.create_user(role='host')
@@ -255,28 +255,7 @@ async def test_book_free_no_fee(donorfy: DonorfyActor, factory: Factory, dummy_s
     )
     r = await cli.json_post(url('event-book-tickets'), data=data)
     assert r.status == 200, await r.text()
-    trans_data = dummy_server.app['post_data']['POST donorfy_api_root/standard/transactions']
-    assert len(trans_data) == 1
-    assert trans_data[0] == {
-        'ExistingConstituentId': '123456',
-        'Channel': 'nosht-supper-clubs',
-        'Currency': 'gbp',
-        'Campaign': 'supper-clubs:the-event-name',
-        'PaymentMethod': 'Offline Payment',
-        'Product': 'Event Ticket(s)',
-        'Fund': 'Unrestricted General',
-        'Department': '220 Ticket Sales',
-        'BankAccount': 'Unrestricted Account',
-        'DatePaid': CloseToNow(),
-        'Amount': 10.0,
-        'ProcessingCostsAmount': 0,
-        'Quantity': 1,
-        'Acknowledgement': 'supper-clubs-thanks',
-        'AcknowledgementText': RegexStr('Ticket ID: .*'),
-        'Reference': 'Events.HUF:supper-clubs the-event-name',
-        'AddGiftAidDeclaration': False,
-        'GiftAidClaimed': False,
-    }
+    assert 'POST donorfy_api_root/standard/transactions' not in dummy_server.app['post_data']
 
 
 async def test_donate(donorfy: DonorfyActor, factory: Factory, dummy_server, db_conn, cli, url, login):

--- a/py/tests/test_events.py
+++ b/py/tests/test_events.py
@@ -765,6 +765,13 @@ async def test_event_tickets_host(cli, url, db_conn, factory: Factory, login):
             },
         ],
     }
+    await db_conn.execute('update tickets set price=null')
+
+    r = await cli.get(url('event-tickets', id=factory.event_id))
+    assert r.status == 200, await r.text()
+    data = await r.json()
+    assert len(data['tickets']) == 1
+    assert data['tickets'][0]['price'] is None
 
 
 async def test_event_tickets_admin(cli, url, db_conn, factory: Factory, login):

--- a/py/tests/test_export.py
+++ b/py/tests/test_export.py
@@ -5,6 +5,7 @@ from io import StringIO
 from pytest_toolbox.comparison import CloseToNow, RegexStr
 
 from web.utils import encrypt_json
+
 from .conftest import Factory
 
 

--- a/py/tests/test_export.py
+++ b/py/tests/test_export.py
@@ -4,6 +4,7 @@ from io import StringIO
 
 from pytest_toolbox.comparison import CloseToNow, RegexStr
 
+from web.utils import encrypt_json
 from .conftest import Factory
 
 
@@ -165,9 +166,19 @@ async def test_ticket_export(cli, url, login, factory: Factory, db_conn):
     )
     await factory.buy_tickets(await factory.create_reservation())
     await factory.buy_tickets(await factory.create_reservation())
-    await login()
+
     ticket_id = await db_conn.fetchval('SELECT id FROM tickets ORDER BY id DESC LIMIT 1')
     await db_conn.execute('UPDATE tickets SET user_id=NULL WHERE id=$1', ticket_id)
+
+    admin_user_id = await factory.create_user(email='admin@example.com', first_name='Admin', last_name='Istrator')
+    await login(email='admin@example.com')
+    res = await factory.create_reservation(admin_user_id)
+    data = dict(
+        booking_token=encrypt_json(cli.app['main_app'], res.dict()),
+        book_action='buy-tickets-offline',
+    )
+    r = await cli.json_post(url('event-book-tickets'), data=data)
+    assert r.status == 200, await r.text()
 
     r = await cli.get(url('export', type='tickets'))
     assert r.status == 200
@@ -216,6 +227,27 @@ async def test_ticket_export(cli, url, login, factory: Factory, db_conn):
             'buyer_user_id': str(factory.user_id),
             'buyer_first_name': 'Frank',
             'buyer_last_name': 'Spencer',
+        },
+        {
+            'id': RegexStr(r'\d+'),
+            'ticket_first_name': '',
+            'ticket_last_name': '',
+            'status': 'booked',
+            'booking_action': 'buy-tickets-offline',
+            'price': '',
+            'extra_donated': '',
+            'created_ts': RegexStr(r'\d{4}.*'),
+            'extra_info': '',
+            'ticket_type_id': ticket_type,
+            'ticket_type_name': 'Standard',
+            'event_id': str(factory.event_id),
+            'event_slug': 'the-event-name',
+            'guest_user_id': str(admin_user_id),
+            'guest_first_name': 'Admin',
+            'guest_last_name': 'Istrator',
+            'buyer_user_id': str(admin_user_id),
+            'buyer_first_name': 'Admin',
+            'buyer_last_name': 'Istrator',
         },
     ]
 

--- a/py/web/stripe.py
+++ b/py/web/stripe.py
@@ -96,7 +96,8 @@ async def book_free(m: BookFreeModel, company_id: int, session: dict, app, conn:
                 type=m.book_action,
             )
         )
-        # market the tickets a price=0 although they could all already be zero, this avoids reporting false revenue
+        # mark the tickets as price=0 although they could all already be zero,
+        # this avoids reporting false revenue for buy-tickets-offline, see #237
         await conn.execute(
             """
             UPDATE tickets SET status='booked', booked_action=$1, price=null, extra_donated=null

--- a/py/web/stripe.py
+++ b/py/web/stripe.py
@@ -96,8 +96,12 @@ async def book_free(m: BookFreeModel, company_id: int, session: dict, app, conn:
                 type=m.book_action,
             )
         )
+        # market the tickets a price=0 although they could all already be zero, this avoids reporting false revenue
         await conn.execute(
-            "UPDATE tickets SET status='booked', booked_action=$1 WHERE reserve_action=$2",
+            """
+            UPDATE tickets SET status='booked', booked_action=$1, price=null, extra_donated=null
+            WHERE reserve_action=$2
+            """,
             confirm_action_id, res.action_id,
         )
         await conn.execute('SELECT check_tickets_remaining($1, $2)', res.event_id, app['settings'].ticket_ttl)


### PR DESCRIPTION
1.5 hours.

Not record revenue on tickets which were "bought" (e.g. booked with no stripe transaction) by admins. This should work both in donorfy and when viewing events.