### PR TITLE
Update openssl

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM python:3.6-alpine3.8
 
-RUN apk add -U gcc g++ musl-dev zlib-dev libuv libffi-dev make openssl-dev git jpeg-dev openjpeg libjpeg-turbo tiff-dev
+RUN apk add -U gcc g++ musl-dev zlib-dev libuv libffi-dev make libressl-dev git jpeg-dev openjpeg libjpeg-turbo tiff-dev
 
 ADD ./py/requirements.txt /home/root/requirements.txt
 RUN pip install -r /home/root/requirements.txt

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,6 +1,6 @@
-FROM python:3.6-alpine3.8
+FROM python:3.6-alpine3.9
 
-RUN apk add -U gcc g++ musl-dev zlib-dev libuv libffi-dev make libressl-dev git jpeg-dev openjpeg libjpeg-turbo tiff-dev
+RUN apk add -U gcc g++ musl-dev zlib-dev libuv libffi-dev make openssl-dev git jpeg-dev openjpeg libjpeg-turbo tiff-dev
 
 ADD ./py/requirements.txt /home/root/requirements.txt
 RUN pip install -r /home/root/requirements.txt

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,6 +1,6 @@
 # ===============================================
 # js build stage
-FROM python:2.7-alpine3.8 as js-build
+FROM python:2.7-alpine3.9 as js-build
 RUN apk --no-cache add nodejs npm yarn make g++
 WORKDIR /home/root
 
@@ -31,7 +31,7 @@ FROM nosht-python-build as python-build
 
 # ===============================================
 # final image
-FROM python:3.6-alpine3.8
+FROM python:3.6-alpine3.9
 COPY --from=python-build /usr/local/lib/python3.6/site-packages /usr/local/lib/python3.6/site-packages
 COPY --from=python-build /lib/* /lib/
 COPY --from=python-build /usr/lib/* /usr/lib/

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -4,7 +4,7 @@ FROM nosht-python-build as python-build
 
 # ===============================================
 # final image
-FROM python:3.6-alpine3.8
+FROM python:3.6-alpine3.9
 COPY --from=python-build /usr/local/lib/python3.6/site-packages /usr/local/lib/python3.6/site-packages
 COPY --from=python-build /lib/* /lib/
 COPY --from=python-build /usr/lib/* /usr/lib/


### PR DESCRIPTION
In order to successfully update to cryptography@3.2 we require openssl@1.1.1 which ships with Alpine from 3.9